### PR TITLE
add no-build-isolation

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --ignore-installed
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --ignore-installed --no-build-isolation
   number: 0
 
 requirements:


### PR DESCRIPTION
jsonschema-path 0.3.2 

**Destination channel:** defaults

### Links

- [Upstream repository](https://github.com/p1c2u/jsonschema-path)
- Relevant dependency PRs:
  - moto needs this dependency in main